### PR TITLE
Downgrade browser base version for Firefox browsers.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.4
+          go-version: ~1.20.5
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,3 @@ jobs:
         with:
           files: 'dist/*'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Release docs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ci/docs.sh $RELEASE_VERSION ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.4
+          go-version: ~1.20.5
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.4
+          go-version: ~1.20.5
 
       - uses: actions/cache@v3
         with:

--- a/static/firefox/apt/Dockerfile
+++ b/static/firefox/apt/Dockerfile
@@ -1,4 +1,4 @@
-FROM browsers/base:7.4.0
+FROM browsers/base:7.3.6
 
 ARG VERSION
 ARG PACKAGE=firefox

--- a/static/firefox/local/Dockerfile
+++ b/static/firefox/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM browsers/base:7.4.0
+FROM browsers/base:7.3.6
 
 ARG VERSION=noop
 ARG PACKAGE=firefox


### PR DESCRIPTION
Downgrade the beowsers/base image to version 7.3.6 to fix Firefox issues as this version uses Ubuntu 20.04. 
Later versions of buntu 22.04 are supported by Edge and Chrome, but Firefox needs to change to build with snap instead of apt. 
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
