### PR TITLE
[QSDK-9929]  Update Chrome Dev builder

### DIFF
--- a/build/chrome.go
+++ b/build/chrome.go
@@ -138,8 +138,11 @@ func (c *Chrome) channelToBuildArgs() []string {
 func (c *Chrome) parseChromeDriverVersion(pkgVersion string) (string, error) {
 	version := c.DriverVersion
 	if version == LatestVersion {
-		const baseUrl = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
-		v, err := c.getLatestChromeDriver(baseUrl, pkgVersion)
+		baseURL := "https://chromedriver.storage.googleapis.com/"
+		if c.BrowserChannel == "beta" || c.BrowserChannel == "stage" {
+			baseURL = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
+		}
+		v, err := c.getLatestChromeDriver(baseURL, pkgVersion)
 		if err != nil {
 			return "", err
 		}
@@ -147,6 +150,7 @@ func (c *Chrome) parseChromeDriverVersion(pkgVersion string) (string, error) {
 	}
 	return version, nil
 }
+
 
 func (c *Chrome) downloadChromeDriver(dir string, version string) error {
 	fmt.Println("VERSION", version)
@@ -194,7 +198,7 @@ func (c *Chrome) getLatestChromeDriver(baseUrl string, pkgVersion string) (strin
     // Browser channel stable
     if channel == "Stable" {
         chromeBuildVersion := buildVersion(pkgVersion)
-        u := "https://chromedriver.storage.googleapis.com/" + fmt.Sprintf("LATEST_RELEASE_%s", chromeBuildVersion)
+        u := baseUrl + fmt.Sprintf("LATEST_RELEASE_%s", chromeBuildVersion)
         v, err := fetchVersionStable(u)
         if err == nil {
             return v, nil

--- a/build/chrome.go
+++ b/build/chrome.go
@@ -139,7 +139,7 @@ func (c *Chrome) parseChromeDriverVersion(pkgVersion string) (string, error) {
 	version := c.DriverVersion
 	if version == LatestVersion {
 		baseURL := "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
-		if c.BrowserChannel == "stable" {
+		if c.BrowserChannel == "default" {
 			baseURL = "https://chromedriver.storage.googleapis.com/"
 		}
 		v, err := c.getLatestChromeDriver(baseURL, pkgVersion)
@@ -154,7 +154,7 @@ func (c *Chrome) parseChromeDriverVersion(pkgVersion string) (string, error) {
 
 func (c *Chrome) downloadChromeDriver(dir string, version string) error {
 	u := fmt.Sprintf("https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/%s/linux64/chromedriver-linux64.zip", version)
-	if c.BrowserChannel == "stable" {
+	if c.BrowserChannel == "default" {
 		u = fmt.Sprintf("http://chromedriver.storage.googleapis.com/%s/chromedriver_linux64.zip", version)
 	}
 	_, err := downloadDriver(u, chromeDriverBinary, dir)

--- a/build/chrome.go
+++ b/build/chrome.go
@@ -139,7 +139,7 @@ func (c *Chrome) parseChromeDriverVersion(pkgVersion string) (string, error) {
 	version := c.DriverVersion
 	if version == LatestVersion {
 		baseURL := "https://chromedriver.storage.googleapis.com/"
-		if c.BrowserChannel == "beta" || c.BrowserChannel == "stage" {
+		if c.BrowserChannel == "beta" || c.BrowserChannel == "dev" {
 			baseURL = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
 		}
 		v, err := c.getLatestChromeDriver(baseURL, pkgVersion)
@@ -153,11 +153,10 @@ func (c *Chrome) parseChromeDriverVersion(pkgVersion string) (string, error) {
 
 
 func (c *Chrome) downloadChromeDriver(dir string, version string) error {
-	fmt.Println("VERSION", version)
-	u := fmt.Sprintf("https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/%s/linux64/chromedriver-linux64.zip", version)
-    if version == LatestVersion {
-        u = fmt.Sprintf("http://chromedriver.storage.googleapis.com/%s/chromedriver_linux64.zip", version)
-    }
+	u := fmt.Sprintf("http://chromedriver.storage.googleapis.com/%s/chromedriver_linux64.zip", version)
+	if c.BrowserChannel == "beta" || c.BrowserChannel == "dev" {
+		u = fmt.Sprintf("https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/%s/linux64/chromedriver-linux64.zip", version)
+	}
 	_, err := downloadDriver(u, chromeDriverBinary, dir)
 	if err != nil {
 		return fmt.Errorf("download chromedriver: %v", err)

--- a/build/chrome.go
+++ b/build/chrome.go
@@ -138,9 +138,9 @@ func (c *Chrome) channelToBuildArgs() []string {
 func (c *Chrome) parseChromeDriverVersion(pkgVersion string) (string, error) {
 	version := c.DriverVersion
 	if version == LatestVersion {
-		baseURL := "https://chromedriver.storage.googleapis.com/"
-		if c.BrowserChannel == "beta" || c.BrowserChannel == "dev" {
-			baseURL = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
+		baseURL := "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
+		if c.BrowserChannel == "stable" {
+			baseURL = "https://chromedriver.storage.googleapis.com/"
 		}
 		v, err := c.getLatestChromeDriver(baseURL, pkgVersion)
 		if err != nil {
@@ -153,9 +153,9 @@ func (c *Chrome) parseChromeDriverVersion(pkgVersion string) (string, error) {
 
 
 func (c *Chrome) downloadChromeDriver(dir string, version string) error {
-	u := fmt.Sprintf("http://chromedriver.storage.googleapis.com/%s/chromedriver_linux64.zip", version)
-	if c.BrowserChannel == "beta" || c.BrowserChannel == "dev" {
-		u = fmt.Sprintf("https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/%s/linux64/chromedriver-linux64.zip", version)
+	u := fmt.Sprintf("https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/%s/linux64/chromedriver-linux64.zip", version)
+	if c.BrowserChannel == "stable" {
+		u = fmt.Sprintf("http://chromedriver.storage.googleapis.com/%s/chromedriver_linux64.zip", version)
 	}
 	_, err := downloadDriver(u, chromeDriverBinary, dir)
 	if err != nil {

--- a/build/file.go
+++ b/build/file.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/cheggaaa/pb.v1"
 	"io"
 	"io/ioutil"
 	"log"
@@ -17,6 +16,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/cheggaaa/pb.v1"
 )
 
 const (
@@ -105,6 +106,7 @@ func extractFile(data []byte, filename string, outputDir string) (string, error)
 
 // Based on http://stackoverflow.com/questions/20357223/easy-way-to-unzip-file-with-golang
 func unzip(data []byte, fileName string, outputDir string) (string, error) {
+	log.Printf("unzip")
 	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 
 	// Closure to address file descriptors issue with all the deferred .Close() methods
@@ -115,7 +117,12 @@ func unzip(data []byte, fileName string, outputDir string) (string, error) {
 		}
 		defer rc.Close()
 
-		outputPath := filepath.Join(outputDir, f.Name)
+		fName := f.Name
+		if strings.Contains(f.Name, "/") {
+			fName = strings.Split(f.Name, "/")[1]
+		}
+		
+		outputPath := filepath.Join(outputDir, fName)
 
 		if f.FileInfo().IsDir() {
 			return "", fmt.Errorf("can only unzip files but %s is a directory", f.Name)
@@ -130,7 +137,11 @@ func unzip(data []byte, fileName string, outputDir string) (string, error) {
 
 	if err == nil {
 		for _, f := range zr.File {
-			if f.Name == fileName {
+			fName := f.Name
+			if strings.Contains(f.Name, "/") {
+				fName = strings.Split(f.Name, "/")[1]
+			}
+			if fName == fileName {
 				return extractAndWriteFile(f)
 			}
 		}

--- a/build/file.go
+++ b/build/file.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"gopkg.in/cheggaaa/pb.v1"
 	"io"
 	"io/ioutil"
 	"log"
@@ -16,8 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"gopkg.in/cheggaaa/pb.v1"
 )
 
 const (

--- a/build/file.go
+++ b/build/file.go
@@ -106,7 +106,6 @@ func extractFile(data []byte, filename string, outputDir string) (string, error)
 
 // Based on http://stackoverflow.com/questions/20357223/easy-way-to-unzip-file-with-golang
 func unzip(data []byte, fileName string, outputDir string) (string, error) {
-	log.Printf("unzip")
 	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 
 	// Closure to address file descriptors issue with all the deferred .Close() methods


### PR DESCRIPTION
Current implementation uses the new API endpoint to retrieve Chromw webdriver.

Context:
The Chrome dev since M115 will not find webdriver from the googleapis link. 
The current info can be returned from JSON endpoint fo both the browser version and webdriver version on all 4 browser channels. 
https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json

Task requires to update Chrome build scripts for the Go project. Once the M115 is promoted all the way to Stable, the JSON endpoint will have webdriver link. Currently exception is Stable version as it has not yet reached in JSON to have webdriver and uses the previous URL. 


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
