### PR TITLE
Fix Microsoft Edge browser build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,29 @@ This repository contains [Docker](http://docker.com/) build files to be used for
 
 ### Android: [![Android Docker Pulls](https://img.shields.io/docker/pulls/selenoid/android.svg)](https://hub.docker.com/r/selenoid/android)
 
-## Building Images
+## Build the binary
 
-Moved to: http://aerokube.com/images/latest/#_building_images
+### MacOS
+1. Install go environment via homebrew or direct download from https://go.dev/doc/install. 
+Check with go.mod and CI scripts to align the go version.
+Setup go path:
+```
+export GOPATH=/Users/<<USER>>/go
+export PATH=$GOPATH/bin:$PATH
+```
+
+2. Install and run the packager for static Dockerfiles (required if Dockerfiles are modified):
+```
+go install github.com/markbates/pkger/cmd/pkger@latest
+go install github.com/mitchellh/gox@latest # cross compile
+go generate github.com/aerokube/images
+```
+3. Build the image builder binary:
+```
+go clean
+go build
+```
+Build artifacts will be present in /dist directory.
 
 ## Image information
 Moved to: http://aerokube.com/images/latest/#_browser_image_information

--- a/build/edge.go
+++ b/build/edge.go
@@ -104,7 +104,7 @@ func (c *Edge) channelToBuildArgs() []string {
 	case "beta":
 		return []string{"PACKAGE=microsoft-edge-beta", "INSTALL_DIR=msedge-beta"}
 	case "dev":
-		return []string{"PACKAGE=microsoft-edge-dev", "INSTALL_DIR=msedge-dev"}
+		return []string{"PACKAGE=microsoft-edge-unstable", "INSTALL_DIR=msedge-dev"}
 	default:
 		return []string{}
 	}

--- a/static/edge/apt/Dockerfile
+++ b/static/edge/apt/Dockerfile
@@ -7,8 +7,10 @@ ARG INSTALL_DIR=msedge
 LABEL browser=$PACKAGE:$VERSION
 
 RUN \
-        curl -s https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-        echo 'deb [arch=amd64] https://packages.microsoft.com/repos/edge stable main' > /etc/apt/sources.list.d/microsoft-edge.list && \
+        apt-get update && \
+        apt-get -y --no-install-recommends install software-properties-common apt-transport-https curl ca-certificates && \
+        curl -fSsL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /usr/share/keyrings/microsoft-edge.gpg > /dev/null && \
+        echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-edge.gpg] https://packages.microsoft.com/repos/edge stable main' | tee /etc/apt/sources.list.d/microsoft-edge.list && \
         apt-get update && \
         apt-get -y --no-install-recommends install iproute2 iptables $PACKAGE=$VERSION && \
         (  \


### PR DESCRIPTION
1. Microsoft Edge now has the following change in Ubuntun apt package name from microsoft-edge-dev to microsoft-edge-unstable. 
2. GPG key installation steps updated as this was deprecated. 
3. Added Go build notes for images binary on MacOS. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
