### PR TITLE
Revert edge_dev package rename.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,10 @@ jobs:
         env:
           CGO_ENABLED: 0
 
-      - name: Latest docs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ci/docs.sh latest ${{ secrets.GITHUB_TOKEN }}
+      # - name: Latest docs
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: ci/docs.sh latest ${{ secrets.GITHUB_TOKEN }}
 
       - uses: release-drafter/release-drafter@v5
         env:

--- a/README.md
+++ b/README.md
@@ -38,5 +38,13 @@ go build
 ```
 Build artifacts will be present in /dist directory.
 
+4. Publish the `images` Go binary artifacts. 
+First merge the code with `master` branch. 
+Then use `repository tags section` to manually create a new release and tag with generated release notes. 
+The release CI job will be triggered via `Github Actions` to publish the release with the build artifacts.
+
 ## Image information
-Moved to: http://aerokube.com/images/latest/#_browser_image_information
+Twilio built browsers use the images Go binary with `browser-validations` (BV) project. 
+https://github.com/twilio/browser-validations
+
+Check the latest published image tags on the public Docker registry: https://hub.docker.com/r/twilio/selenoid

--- a/build/edge.go
+++ b/build/edge.go
@@ -104,7 +104,7 @@ func (c *Edge) channelToBuildArgs() []string {
 	case "beta":
 		return []string{"PACKAGE=microsoft-edge-beta", "INSTALL_DIR=msedge-beta"}
 	case "dev":
-		return []string{"PACKAGE=microsoft-edge-unstable", "INSTALL_DIR=msedge-dev"}
+		return []string{"PACKAGE=microsoft-edge-dev", "INSTALL_DIR=msedge-dev"}
 	default:
 		return []string{}
 	}


### PR DESCRIPTION
Fix incorrect dev Edge package name. 

Fix CI Actions error on Merge. 
Should not attempt to publish docs to Aerokube repo. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
