### PR TITLE
Fix and check network utils

### DIFF
--- a/static/chrome/apt/Dockerfile
+++ b/static/chrome/apt/Dockerfile
@@ -10,10 +10,16 @@ RUN \
         curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
         echo 'deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google.list && \
         apt-get update && \
-        apt-get -y --no-install-recommends install iproute2 iptables lsof python3.11-pip $PACKAGE=$VERSION && \
+        apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \
+        # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
+        pip3 uninstall -y SimpleSQLite==1.5.1 \
+        pip3 install SimpleSQLite==1.4.0 \
         sed -i -e 's@exec -a "$0" "$HERE/chrome"@& --no-sandbox --disable-gpu@' /opt/google/$INSTALL_DIR/google-chrome && \
         chown root:root /opt/google/$INSTALL_DIR/chrome-sandbox && \
         chmod 4755 /opt/google/$INSTALL_DIR/chrome-sandbox && \
+        ip -V \
+        iptables -V \
+        tcset -V \
         google-chrome --version && \
         rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*

--- a/static/chrome/apt/Dockerfile
+++ b/static/chrome/apt/Dockerfile
@@ -13,13 +13,13 @@ RUN \
         apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \
         # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-        pip3 uninstall -y SimpleSQLite==1.5.1 \
-        pip3 install SimpleSQLite==1.4.0 \
+        pip3 uninstall -y SimpleSQLite==1.5.1 && \
+        pip3 install SimpleSQLite==1.4.0 && \
+        ip -V && \
+        iptables -V && \
+        tcset -V && \
         sed -i -e 's@exec -a "$0" "$HERE/chrome"@& --no-sandbox --disable-gpu@' /opt/google/$INSTALL_DIR/google-chrome && \
         chown root:root /opt/google/$INSTALL_DIR/chrome-sandbox && \
         chmod 4755 /opt/google/$INSTALL_DIR/chrome-sandbox && \
-        ip -V \
-        iptables -V \
-        tcset -V \
         google-chrome --version && \
         rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*

--- a/static/chrome/apt/Dockerfile
+++ b/static/chrome/apt/Dockerfile
@@ -15,6 +15,7 @@ RUN \
         # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
         pip3 uninstall -y SimpleSQLite==1.5.1 && \
         pip3 install SimpleSQLite==1.4.0 && \
+        # Check network utilities version
         ip -V && \
         iptables -V && \
         tcset -V && \

--- a/static/chrome/apt/Dockerfile
+++ b/static/chrome/apt/Dockerfile
@@ -10,7 +10,7 @@ RUN \
         curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
         echo 'deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/google.list && \
         apt-get update && \
-        apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip $PACKAGE=$VERSION && \
+        apt-get -y --no-install-recommends install iproute2 iptables lsof python3.11-pip $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \
         sed -i -e 's@exec -a "$0" "$HERE/chrome"@& --no-sandbox --disable-gpu@' /opt/google/$INSTALL_DIR/google-chrome && \
         chown root:root /opt/google/$INSTALL_DIR/chrome-sandbox && \

--- a/static/chromium/apt/Dockerfile
+++ b/static/chromium/apt/Dockerfile
@@ -19,6 +19,7 @@ RUN \
     # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
     pip3 uninstall -y SimpleSQLite==1.5.1 && \
     pip3 install SimpleSQLite==1.4.0 && \
+    # Check network utilities version
     ip -V && \
     iptables -V && \
     tcset -V && \

--- a/static/chromium/apt/Dockerfile
+++ b/static/chromium/apt/Dockerfile
@@ -17,10 +17,10 @@ RUN \
       chromium-chromedriver=${VERSION} && \
     pip3 install --default-timeout=300 tcconfig && \
     # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-    pip3 uninstall -y SimpleSQLite==1.5.1 \
-    pip3 install SimpleSQLite==1.4.0 \
-    ip -V \
-    iptables -V \
-    tcset -V \
+    pip3 uninstall -y SimpleSQLite==1.5.1 && \
+    pip3 install SimpleSQLite==1.4.0 && \
+    ip -V && \
+    iptables -V && \
+    tcset -V && \
     chromium-browser --version && \
     rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*

--- a/static/chromium/apt/Dockerfile
+++ b/static/chromium/apt/Dockerfile
@@ -16,5 +16,11 @@ RUN \
       ${PACKAGE}=${VERSION} \
       chromium-chromedriver=${VERSION} && \
     pip3 install --default-timeout=300 tcconfig && \
+    # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
+    pip3 uninstall -y SimpleSQLite==1.5.1 \
+    pip3 install SimpleSQLite==1.4.0 \
+    ip -V \
+    iptables -V \
+    tcset -V \
     chromium-browser --version && \
     rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*

--- a/static/edge/apt/Dockerfile
+++ b/static/edge/apt/Dockerfile
@@ -14,11 +14,17 @@ RUN \
         apt-get update && \
         apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \
+        # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
+        pip3 uninstall -y SimpleSQLite==1.5.1 \
+        pip3 install SimpleSQLite==1.4.0 \
         (  \
           sed -i -e 's@exec -a "$0" "$HERE/msedge"@& --no-sandbox --disable-gpu@' /opt/microsoft/$INSTALL_DIR/$PACKAGE || \
           sed -i -e 's@exec -a "$0" "$HERE/msedge"@& --no-sandbox --disable-gpu@' /opt/microsoft/$INSTALL_DIR/microsoft-edge \
         ) && \
         chown root:root /opt/microsoft/$INSTALL_DIR/msedge-sandbox && \
         chmod 4755 /opt/microsoft/$INSTALL_DIR/msedge-sandbox && \
+        ip -V \
+        iptables -V \
+        tcset -V \
         microsoft-edge --version && \
         rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*

--- a/static/edge/apt/Dockerfile
+++ b/static/edge/apt/Dockerfile
@@ -15,16 +15,16 @@ RUN \
         apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \
         # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-        pip3 uninstall -y SimpleSQLite==1.5.1 \
-        pip3 install SimpleSQLite==1.4.0 \
+        pip3 uninstall -y SimpleSQLite==1.5.1 && \
+        pip3 install SimpleSQLite==1.4.0 && \
+        ip -V && \
+        iptables -V && \
+        tcset -V && \
         (  \
           sed -i -e 's@exec -a "$0" "$HERE/msedge"@& --no-sandbox --disable-gpu@' /opt/microsoft/$INSTALL_DIR/$PACKAGE || \
           sed -i -e 's@exec -a "$0" "$HERE/msedge"@& --no-sandbox --disable-gpu@' /opt/microsoft/$INSTALL_DIR/microsoft-edge \
         ) && \
         chown root:root /opt/microsoft/$INSTALL_DIR/msedge-sandbox && \
         chmod 4755 /opt/microsoft/$INSTALL_DIR/msedge-sandbox && \
-        ip -V \
-        iptables -V \
-        tcset -V \
         microsoft-edge --version && \
         rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*

--- a/static/edge/apt/Dockerfile
+++ b/static/edge/apt/Dockerfile
@@ -17,6 +17,7 @@ RUN \
         # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
         pip3 uninstall -y SimpleSQLite==1.5.1 && \
         pip3 install SimpleSQLite==1.4.0 && \
+        # Check network utilities version
         ip -V && \
         iptables -V && \
         tcset -V && \

--- a/static/firefox/apt/Dockerfile
+++ b/static/firefox/apt/Dockerfile
@@ -19,6 +19,7 @@ RUN  \
         # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
         pip3 uninstall -y SimpleSQLite==1.5.1 && \
         pip3 install SimpleSQLite==1.4.0 && \
+        # Check network utilities version
         ip -V && \
         iptables -V && \
         tcset -V && \

--- a/static/firefox/apt/Dockerfile
+++ b/static/firefox/apt/Dockerfile
@@ -16,6 +16,12 @@ RUN  \
         apt-get update && \
         apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip libavcodec58 $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \
+        # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
+        pip3 uninstall -y SimpleSQLite==1.5.1 \
+        pip3 install SimpleSQLite==1.4.0 \
         ( [ "$PACKAGE" != "firefox" ] && ln /usr/bin/$PACKAGE /usr/bin/firefox ) || true && \
+        ip -V \
+        iptables -V \
+        tcset -V \
         firefox --version && \
         rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*

--- a/static/firefox/apt/Dockerfile
+++ b/static/firefox/apt/Dockerfile
@@ -17,11 +17,11 @@ RUN  \
         apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip libavcodec58 $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \
         # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-        pip3 uninstall -y SimpleSQLite==1.5.1 \
-        pip3 install SimpleSQLite==1.4.0 \
+        pip3 uninstall -y SimpleSQLite==1.5.1 && \
+        pip3 install SimpleSQLite==1.4.0 && \
+        ip -V && \
+        iptables -V && \
+        tcset -V && \
         ( [ "$PACKAGE" != "firefox" ] && ln /usr/bin/$PACKAGE /usr/bin/firefox ) || true && \
-        ip -V \
-        iptables -V \
-        tcset -V \
         firefox --version && \
         rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*

--- a/static/firefox/local/Dockerfile
+++ b/static/firefox/local/Dockerfile
@@ -14,11 +14,11 @@ RUN \
                 apt-get -y --no-install-recommends install libavcodec58 iproute2 iptables lsof python3-pip && \
                 pip3 install --default-timeout=300 tcconfig && \
                 # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-                pip3 uninstall -y SimpleSQLite==1.5.1 \
-                pip3 install SimpleSQLite==1.4.0 \
-                ip -V \
-                iptables -V \
-                tcset -V \
+                pip3 uninstall -y SimpleSQLite==1.5.1 && \
+                pip3 install SimpleSQLite==1.4.0 && \
+                ip -V && \
+                iptables -V && \
+                tcset -V && \
                 apt-get -y install libgtk-3-0 libstartup-notification0 libdbus-glib-1-2 \
             ) || \
             ( \
@@ -28,11 +28,11 @@ RUN \
                 apt-get -y --no-install-recommends install libavcodec58 iproute2 iptables lsof python3-pip && \
                 pip3 install --default-timeout=300 tcconfig && \
                 # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-                pip3 uninstall -y SimpleSQLite==1.5.1 \
-                pip3 install SimpleSQLite==1.4.0 \
-                ip -V \
-                iptables -V \
-                tcset -V \
+                pip3 uninstall -y SimpleSQLite==1.5.1 && \
+                pip3 install SimpleSQLite==1.4.0 && \
+                ip -V && \
+                iptables -V && \
+                tcset -V && \
                 apt-get -y install libc6:i386 libncurses5:i386 libstdc++6:i386 libgtk-3-0:i386 libasound2:i386 libdbus-glib-1-2:i386 libxt6:i386 libatomic1:i386 libcairo-gobject2:i386 libstartup-notification0:i386 libx11-xcb1:i386 && \
                 mkdir flashplayer && \
                 cd flashplayer && \

--- a/static/firefox/local/Dockerfile
+++ b/static/firefox/local/Dockerfile
@@ -16,6 +16,7 @@ RUN \
                 # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
                 pip3 uninstall -y SimpleSQLite==1.5.1 && \
                 pip3 install SimpleSQLite==1.4.0 && \
+                # Check network utilities version
                 ip -V && \
                 iptables -V && \
                 tcset -V && \
@@ -30,6 +31,7 @@ RUN \
                 # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
                 pip3 uninstall -y SimpleSQLite==1.5.1 && \
                 pip3 install SimpleSQLite==1.4.0 && \
+                # Check network utilities version
                 ip -V && \
                 iptables -V && \
                 tcset -V && \

--- a/static/firefox/local/Dockerfile
+++ b/static/firefox/local/Dockerfile
@@ -13,6 +13,12 @@ RUN \
                 apt-get update && \
                 apt-get -y --no-install-recommends install libavcodec58 iproute2 iptables lsof python3-pip && \
                 pip3 install --default-timeout=300 tcconfig && \
+                # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
+                pip3 uninstall -y SimpleSQLite==1.5.1 \
+                pip3 install SimpleSQLite==1.4.0 \
+                ip -V \
+                iptables -V \
+                tcset -V \
                 apt-get -y install libgtk-3-0 libstartup-notification0 libdbus-glib-1-2 \
             ) || \
             ( \
@@ -21,6 +27,12 @@ RUN \
                 apt-get update && \
                 apt-get -y --no-install-recommends install libavcodec58 iproute2 iptables lsof python3-pip && \
                 pip3 install --default-timeout=300 tcconfig && \
+                # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
+                pip3 uninstall -y SimpleSQLite==1.5.1 \
+                pip3 install SimpleSQLite==1.4.0 \
+                ip -V \
+                iptables -V \
+                tcset -V \
                 apt-get -y install libc6:i386 libncurses5:i386 libstdc++6:i386 libgtk-3-0:i386 libasound2:i386 libdbus-glib-1-2:i386 libxt6:i386 libatomic1:i386 libcairo-gobject2:i386 libstartup-notification0:i386 libx11-xcb1:i386 && \
                 mkdir flashplayer && \
                 cd flashplayer && \


### PR DESCRIPTION
The following fixes for network utilities:
1. Fix TCSET (tcconfig) crash by dependancy update.
2. Add command checks for version that also serve as checks if the command is installed and works. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
