### PR TITLE
Change endpoint for downloading Chrome

### DIFF
--- a/build/chrome.go
+++ b/build/chrome.go
@@ -149,7 +149,7 @@ func (c *Chrome) parseChromeDriverVersion(pkgVersion string) (string, error) {
 }
 
 func (c *Chrome) downloadChromeDriver(dir string, version string) error {
-	u := fmt.Sprintf("https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/%s/linux64/chromedriver-linux64.zip", version)
+	u := fmt.Sprintf("https://storage.googleapis.com/chrome-for-testing-public/%s/linux64/chromedriver-linux64.zip", version)
 	_, err := downloadDriver(u, chromeDriverBinary, dir)
 	if err != nil {
 		return fmt.Errorf("download chromedriver: %v", err)


### PR DESCRIPTION
Download Chrome from new endpoint https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
