### PR TITLE
Fix apt installation of Firefox browser

### DIFF
--- a/build/firefox.go
+++ b/build/firefox.go
@@ -144,13 +144,13 @@ func (c *Firefox) Build() error {
 func (c *Firefox) channelToBuildArgs() []string {
 	switch c.BrowserChannel {
 	case "beta":
-		return []string{"PPA=ppa:mozillateam/firefox-next"}
+		return []string{"PACKAGE=firefox-beta"}
 	case "dev":
-		return []string{"PACKAGE=firefox-trunk", "PPA=ppa:ubuntu-mozilla-daily/ppa"}
+		return []string{"PACKAGE=firefox-nightly"}
 	case "esr":
-		return []string{"PACKAGE=firefox-esr", "PPA=ppa:mozillateam/ppa"}
+		return []string{"PACKAGE=firefox-esr"}
 	default:
-		return []string{"PPA=ppa:mozillateam/ppa"}
+		return []string{}
 	}
 }
 

--- a/static/firefox/apt/Dockerfile
+++ b/static/firefox/apt/Dockerfile
@@ -8,7 +8,7 @@ LABEL browser=$PACKAGE:$VERSION
 RUN  \
         apt-get update && \
         apt-get install -y software-properties-common wget && \
-        # https://support.mozilla.org/en-US/kb/install-firefox-linux#w_install-firefox-deb-package-for-debian-based-distributions-recommended \
+        # https://support.mozilla.org/en-US/kb/install-firefox-linux#w_install-firefox-deb-package-for-debian-based-distributions-recommended
         install -d -m 0755 /etc/apt/keyrings && \
         wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg -O- | tee /etc/apt/keyrings/packages.mozilla.org.asc > /dev/null && \
         echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" | tee -a /etc/apt/sources.list.d/mozilla.list > /dev/null && \

--- a/static/firefox/apt/Dockerfile
+++ b/static/firefox/apt/Dockerfile
@@ -2,17 +2,17 @@ FROM browsers/base:7.3.6
 
 ARG VERSION
 ARG PACKAGE=firefox
-ARG PPA
 
 LABEL browser=$PACKAGE:$VERSION
 
 RUN  \
-        ( [ "$PPA" != "" ] && \
-            apt-get update && \
-            apt-get install -y software-properties-common && \
-            apt-get update && \
-            add-apt-repository -y $PPA \
-        ) || true && \
+        apt-get update && \
+        apt-get install -y software-properties-common wget && \
+        # https://support.mozilla.org/en-US/kb/install-firefox-linux#w_install-firefox-deb-package-for-debian-based-distributions-recommended \
+        install -d -m 0755 /etc/apt/keyrings && \
+        wget -q https://packages.mozilla.org/apt/repo-signing-key.gpg -O- | tee /etc/apt/keyrings/packages.mozilla.org.asc > /dev/null && \
+        echo "deb [signed-by=/etc/apt/keyrings/packages.mozilla.org.asc] https://packages.mozilla.org/apt mozilla main" | tee -a /etc/apt/sources.list.d/mozilla.list > /dev/null && \
+        printf 'Package: *\nPin: origin packages.mozilla.org\nPin-Priority: 1000\n' | tee /etc/apt/preferences.d/mozilla && \
         apt-get update && \
         apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip libavcodec58 $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \

--- a/static/firefox/local/Dockerfile
+++ b/static/firefox/local/Dockerfile
@@ -2,7 +2,6 @@ FROM browsers/base:7.3.6
 
 ARG VERSION=noop
 ARG PACKAGE=firefox
-ARG PPA=noop
 
 LABEL browser=$PACKAGE:$VERSION
 


### PR DESCRIPTION
This PR fixes the installation steps of Firefox, to correctly download latest stable, beta and dev versions of Firefox.

Dockerfile steps updated based on recommended install instructions: https://support.mozilla.org/en-US/kb/install-firefox-linux#w_install-firefox-deb-package-for-debian-based-distributions-recommended

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
