### PR TITLE
Update base image for Chrome/Firefox/Edge builds

### DIFF
--- a/static/chrome/apt/Dockerfile
+++ b/static/chrome/apt/Dockerfile
@@ -1,4 +1,4 @@
-FROM browsers/base:7.4.0
+FROM browsers/base:7.4.2
 
 ARG VERSION
 ARG PACKAGE=google-chrome-stable
@@ -12,9 +12,6 @@ RUN \
         apt-get update && \
         apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \
-        # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-        pip3 uninstall -y SimpleSQLite==1.5.1 && \
-        pip3 install SimpleSQLite==1.4.0 && \
         # Check network utilities version
         ip -V && \
         iptables -V && \

--- a/static/chrome/local/Dockerfile
+++ b/static/chrome/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM browsers/base:7.4.0
+FROM browsers/base:7.4.2
 
 ARG VERSION=noop
 ARG PACKAGE=google-chrome-stable

--- a/static/edge/apt/Dockerfile
+++ b/static/edge/apt/Dockerfile
@@ -1,4 +1,4 @@
-FROM browsers/base:7.4.0
+FROM browsers/base:7.4.2
 
 ARG VERSION
 ARG PACKAGE=microsoft-edge-stable
@@ -14,9 +14,6 @@ RUN \
         apt-get update && \
         apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \
-        # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-        pip3 uninstall -y SimpleSQLite==1.5.1 && \
-        pip3 install SimpleSQLite==1.4.0 && \
         # Check network utilities version
         ip -V && \
         iptables -V && \

--- a/static/edge/local/Dockerfile
+++ b/static/edge/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM browsers/base:7.4.0
+FROM browsers/base:7.4.2
 
 ARG VERSION=noop
 ARG PACKAGE=microsoft-edge-stable

--- a/static/firefox/apt/Dockerfile
+++ b/static/firefox/apt/Dockerfile
@@ -1,4 +1,4 @@
-FROM browsers/base:7.3.6
+FROM browsers/base:7.4.2
 
 ARG VERSION
 ARG PACKAGE=firefox
@@ -16,9 +16,6 @@ RUN  \
         apt-get update && \
         apt-get -y --no-install-recommends install iproute2 iptables lsof python3-pip libavcodec58 $PACKAGE=$VERSION && \
         pip3 install --default-timeout=300 tcconfig && \
-        # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-        pip3 uninstall -y SimpleSQLite==1.5.1 && \
-        pip3 install SimpleSQLite==1.4.0 && \
         # Check network utilities version
         ip -V && \
         iptables -V && \

--- a/static/firefox/local/Dockerfile
+++ b/static/firefox/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM browsers/base:7.3.6
+FROM browsers/base:7.4.2
 
 ARG VERSION=noop
 ARG PACKAGE=firefox
@@ -12,9 +12,6 @@ RUN \
                 apt-get update && \
                 apt-get -y --no-install-recommends install libavcodec58 iproute2 iptables lsof python3-pip && \
                 pip3 install --default-timeout=300 tcconfig && \
-                # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-                pip3 uninstall -y SimpleSQLite==1.5.1 && \
-                pip3 install SimpleSQLite==1.4.0 && \
                 # Check network utilities version
                 ip -V && \
                 iptables -V && \
@@ -27,9 +24,6 @@ RUN \
                 apt-get update && \
                 apt-get -y --no-install-recommends install libavcodec58 iproute2 iptables lsof python3-pip && \
                 pip3 install --default-timeout=300 tcconfig && \
-                # Workaround for tcset command (https://github.com/thombashi/tcconfig/issues/177)
-                pip3 uninstall -y SimpleSQLite==1.5.1 && \
-                pip3 install SimpleSQLite==1.4.0 && \
                 # Check network utilities version
                 ip -V && \
                 iptables -V && \


### PR DESCRIPTION
tcconfig 0.30.0 has dropped support for Python3.8, causing tcset/tcdel commands to fail: https://github.com/thombashi/tcconfig/releases/tag/v0.30.0

This PR updates the base image version to the latest with Python 3.10 installed

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
