### PR TITLE
QSDK-11358: Fix Edge install failing on Beta and Stable

### DIFF
--- a/static/edge/apt/Dockerfile
+++ b/static/edge/apt/Dockerfile
@@ -13,7 +13,7 @@ RUN \
         echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-edge.gpg] https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge.list && \
         apt-get update && \
         apt-get -y --no-install-recommends install $PACKAGE=$VERSION || true && \
-        sed -i 's/install_deb822_sources/#install_deb822_sources/' /var/lib/dpkg/info/microsoft-edge-dev.postinst && \
+        sed -i 's/install_deb822_sources/#install_deb822_sources/' /var/lib/dpkg/info/$PACKAGE.postinst && \
         dpkg --configure -a && \
         pip3 install --default-timeout=300 tcconfig && \
         # Check network utilities version


### PR DESCRIPTION
- Fix Edge install failing on Beta and Stable because of the hardcoded file name with -dev
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
